### PR TITLE
Adding metadata to storage.

### DIFF
--- a/src/identity.rs
+++ b/src/identity.rs
@@ -52,6 +52,10 @@ pub trait Trait: system::Trait {
 
 pub type LinkedProof = Vec<u8>;
 
+pub type Avatar = Vec<u8>;
+pub type DisplayName = Vec<u8>;
+pub type TagLine = Vec<u8>;
+
 decl_module! {
     pub struct Module<T: Trait> for enum Call where origin: T::Origin {
         fn deposit_event() = default;
@@ -106,6 +110,16 @@ decl_module! {
 
             <IdentityOf<T>>::insert(identity_hash, (T::IdentityIndex::sa(index), _sender.clone(), None));
             Self::deposit_event(RawEvent::Published(identity_hash, T::IdentityIndex::sa(index), _sender.clone().into()));
+            Ok(())
+        }
+
+        /// Add metadata to sender's account. Always overwrites existing metadata.
+        /// TODO: limit the max length of these user-submitted types?
+        /// TODO: add a field relating to verification?
+        /// TODO: worth adding an event when someone updates their metadata?
+        pub fn add_metadata(origin, avatar: Avatar, display_name : DisplayName, tagline : TagLine) -> Result {
+            let _sender = ensure_signed(origin)?;
+            <IdentityMetadata<T>>::insert(_sender, (avatar, display_name, tagline));
             Ok(())
         }
 
@@ -168,6 +182,8 @@ decl_storage! {
         pub Identities get(identities): Vec<(T::Hash)>;
         /// Actual identity for a given hash, if it's current.
         pub IdentityOf get(identity_of): map T::Hash => Option<(T::IdentityIndex, T::AccountId, Option<LinkedProof>)>;
+        /// User-submitted data associated with an identity
+        pub IdentityMetadata get(identity_metadata): map T::AccountId => (Avatar, DisplayName, TagLine);
         /// The number of linked identities that have been added.
         pub LinkedIdentityCount get(linked_count): usize;
         /// The set of active claims issuers

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,6 +125,10 @@ mod tests {
         Identity::link(Origin::signed(who), identity_hash, proof_link.to_vec())
     }
 
+    fn add_metadata_to_account(who: H256, avatar: &[u8], display_name: &[u8], tagline: &[u8]) -> super::Result {
+        Identity::add_metadata(Origin::signed(who), avatar.to_vec(), display_name.to_vec(), tagline.to_vec())
+    }
+
     fn add_claim_to_identity(who: H256, identity_hash: H256, claim: &[u8]) -> super::Result {
         Identity::add_claim(Origin::signed(who), identity_hash, claim.to_vec())
     }
@@ -214,6 +218,22 @@ mod tests {
             assert_ok!(publish_identity_attestation(public, identity_hash));
             let proof_link: &[u8] = b"www.proof.com/link_of_extra_proof";
             assert_eq!(link_identity_with_proof(other_pub, identity_hash, proof_link), Err("Stored identity does not match sender"));
+        });
+    }
+
+    #[test]
+    fn add_metadata_should_work() {
+        with_externalities(&mut new_test_ext(), || {
+            System::set_block_number(1);
+
+            let pair: Pair = Pair::from_seed(&hex!("9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60"));
+            let avatar: &[u8] = b"OhBQ5kk1PMB025OZ7K2CsjSAeY6xGv+H7dCiEcHu31";
+            let display_name: &[u8] = b"drewstone";
+            let tagline: &[u8] = b"hello world!";
+
+            let public: H256 = pair.public().0.into();
+
+            assert_ok!(add_metadata_to_account(public, avatar, display_name, tagline));
         });
     }
 


### PR DESCRIPTION
Adds a few basic metadata fields to storage: an avatar image, a display name, and a tagline, all associated with a single `AccountId`. Many TBDs remain but this should be enough to get us started.

TO CONSIDER: maybe split this into its own module, unless these fields somehow become explicitly related to `Identity`?