### PR TITLE
Renaming storage.

### DIFF
--- a/src/identity.rs
+++ b/src/identity.rs
@@ -195,7 +195,7 @@ decl_event!(
 );
 
 decl_storage! {
-    trait Store for Module<T: Trait> as IdentityStorage {
+    trait Store for Module<T: Trait> as Identity {
         /// The hashed identities.
         pub Identities get(identities): Vec<(T::Hash)>;
         /// Actual identity for a given hash, if it's current.


### PR DESCRIPTION
Storage naming now inline with substrate's SRML scheme.